### PR TITLE
[EWT-12]: Airflow fix for Stats.timing from datetime to seconds

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1239,7 +1239,7 @@ class SchedulerJob(BaseJob):
                     schedule_delay = dag_run.start_date - expected_start_date
                     Stats.timing(
                         'dagrun.schedule_delay.{dag_id}'.format(dag_id=dag.dag_id),
-                        schedule_delay)
+                        schedule_delay.total_seconds())
                 self.log.info("Created %s", dag_run)
             self._process_task_instances(dag, tis_out)
             self.manage_slas(dag)

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -341,7 +341,7 @@ class DagRun(Base, LoggingMixin):
         if self.state == State.RUNNING:
             return
 
-        duration = (self.end_date - self.start_date)
+        duration = (self.end_date - self.start_date).total_seconds()
         if self.state is State.SUCCESS:
             Stats.timing('dagrun.duration.success.{}'.format(self.dag_id), duration)
         elif self.state == State.FAILED:


### PR DESCRIPTION
Airflow fix for Stats.timing from datetime to seconds