### PR TITLE
[AIRFLOW-5657] Update the upper bound for dill (#6334)

### DIFF
--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.0+twtr21'
+version = '1.10.0+twtr22'

--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,7 @@ def do_setup():
             'bleach==2.1.2',
             'configparser>=3.5.0, <3.6.0',
             'croniter>=0.3.17, <0.4',
-            'dill>=0.2.2, <0.3',
+            'dill>=0.2.2, <0.4',
             'flask>=0.12.4, <0.13',
             'flask-appbuilder>=1.11.1, <2.0.0',
             'flask-admin==1.4.1',


### PR DESCRIPTION
Cherrypicked open source dill version upgrade. Relaunched personal cluster and made sure canary worked. Didn't test xcom which use pickle/dill but it seems safe enough since the new version is been used in Airflow for quite some time now.