### PR TITLE
Relax version requirements

### DIFF
--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.0+twtr21'
+version = '1.10.0+twtr22'

--- a/setup.py
+++ b/setup.py
@@ -272,7 +272,7 @@ def do_setup():
             'bleach==2.1.2',
             'configparser>=3.5.0, <3.6.0',
             'croniter>=0.3.17, <0.4',
-            'dill>=0.2.2, <0.3',
+            'dill>=0.2.2, <0.4',
             'flask>=0.12.4, <0.13',
             'flask-appbuilder>=1.11.1, <2.0.0',
             'flask-admin==1.4.1',


### PR DESCRIPTION
One cherrypick + one change to relax the version requirements of Airflow. Tested canary on internal cluster on this version. Open source PR is up for this change as well.

The diff is showing the changes for the previous release as well, not 100% sure why (e.g. https://github.com/twitter-forks/airflow/blob/1.10%2Btwtr/airflow/version.py shows a different value than the base version here).