### PR TITLE
[CX-16591] Fix regex to work with impersonated clusters

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1490,7 +1490,7 @@ class DagModel(Base, LoggingMixin):
             # the path the webserver uses when it tries to trigger a DAG does not match the
             # existing scheduler path and the DAG can not be found.
             # Also, fix for render code on UI by changing "/code" in views.py
-            path_regex = "airflow_scheduler-.-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[" \
+            path_regex = "airflow_scheduler.*-.-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[" \
                          "0-9a-f]{12}/runs/.*/sandbox/airflow_home"
             path_split = re.split(path_regex, self.fileloc)[1]
             return os.environ.get("AIRFLOW_HOME") + path_split

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,5 +18,5 @@
 # under the License.
 #
 
-version = '1.10.4+twtr7'
+version = '1.10.4+twtr8'
 


### PR DESCRIPTION
Testing done:
Tested the code by hand with a fileloc from my database and made sure the same result was returned with both a regular schedule name and an impersonated scheduler name, also spun up a devel instance (both impersonated and non-impersonated), and made sure the bugs we were seeing previously no longer occurred, and that canary tasks were still running.