### PR TITLE
[EWT-135] updating pool in baseoperator for mock in unittest

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -281,7 +281,7 @@ class BaseOperator(LoggingMixin):
         priority_weight=1,  # type: int
         weight_rule=WeightRule.DOWNSTREAM,  # type: str
         queue=configuration.conf.get('celery', 'default_queue'),  # type: str
-        pool=Pool.DEFAULT_POOL_NAME,  # type: str
+        pool=None,  # type: str
         sla=None,  # type: Optional[timedelta]
         execution_timeout=None,  # type: Optional[timedelta]
         on_failure_callback=None,  # type: Optional[Callable]
@@ -351,7 +351,7 @@ class BaseOperator(LoggingMixin):
         self.retries = retries if retries is not None else \
             int(configuration.conf.get('core', 'default_task_retries', fallback=0))
         self.queue = queue
-        self.pool = pool
+        self.pool = Pool.DEFAULT_POOL_NAME if pool is None else pool
         self.sla = sla
         self.execution_timeout = execution_timeout
         self.on_failure_callback = on_failure_callback

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,5 +18,5 @@
 # under the License.
 #
 
-version = '1.10.4+twtr8'
+version = '1.10.4+twtr9'
 


### PR DESCRIPTION
Currently, the Baseoperator _init_ has an argument pool set to default as:
pool=Pool.DEFAULT_POOL_NAME

Because of this, the following mock is not working:
@patch.object(Pool, "DEFAULT_POOL_NAME", new=None)

To resolve this issue, making pool=None in the argument, and then setting it in code as:
self.pool = Pool.DEFAULT_POOL_NAME if pool is None else pool