### PR TITLE
[CP][AIRFLOW-6561][EWT-290]: Adding priority class and default resource for worker pod.

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -840,3 +840,7 @@ fs_group =
 # The worker pods will be given these static labels, as well as some additional dynamic labels
 # to identify the task.
 # Should be supplied in the format: key = value
+
+[kubernetes_worker_resources]
+# EWT-290: This is added adhoc basis to configure the Airflow worker resources.
+# This should be removed when the similar functionality is available with Airflow upgrade.

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -149,6 +149,7 @@ class KubeConfig:
         )
         self.kube_node_selectors = configuration_dict.get('kubernetes_node_selectors', {})
         self.kube_annotations = configuration_dict.get('kubernetes_annotations', {})
+        self.kube_worker_resources = configuration_dict.get('kubernetes_worker_resources', {})
         self.kube_labels = configuration_dict.get('kubernetes_labels', {})
         self.delete_worker_pods = conf.getboolean(
             self.kubernetes_section, 'delete_worker_pods')

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -260,6 +260,5 @@ class KubernetesRequestFactory:
 
     @staticmethod
     def extract_priority_class(pod, req):
-        print(f"extract_priority_class: {pod.priority_class}")
         if pod.priority_class:
             req['spec']['priorityClassName'] = pod.priority_class

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -257,3 +257,9 @@ class KubernetesRequestFactory:
                     }
                 }
             )
+
+    @staticmethod
+    def extract_priority_class(pod, req):
+        print(f"extract_priority_class: {pod.priority_class}")
+        if pod.priority_class:
+            req['spec']['priorityClassName'] = pod.priority_class

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
@@ -65,6 +65,7 @@ spec:
         self.extract_tolerations(pod, req)
         self.extract_security_context(pod, req)
         self.extract_dnspolicy(pod, req)
+        self.extract_priority_class(pod, req)
         return req
 
 
@@ -135,4 +136,5 @@ spec:
         self.extract_tolerations(pod, req)
         self.extract_security_context(pod, req)
         self.extract_dnspolicy(pod, req)
+        self.extract_priority_class(pod, req)
         return req

--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -113,7 +113,8 @@ class Pod:
             security_context=None,
             configmaps=None,
             pod_runtime_info_envs=None,
-            dnspolicy=None
+            dnspolicy=None,
+            priority_class=None
     ):
         self.image = image
         self.envs = envs or {}
@@ -141,3 +142,4 @@ class Pod:
         self.configmaps = configmaps or []
         self.pod_runtime_info_envs = pod_runtime_info_envs or []
         self.dnspolicy = dnspolicy
+        self.priority_class = priority_class

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,5 +18,5 @@
 # under the License.
 #
 
-version = '1.10.4+twtr9'
+version = '1.10.4+twtr10'
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [ ] EWT-290 add priorityClassName and cpu and memory resource into pod spec definition.
- [ ] The priorityClassName is set as the env (AIRFLOW_POD_PRIORITY_CLASS).
- [ ] The cpu and memory resource are set into the airflow.cfg file under 'kube_worker_resources'


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `flake8`
