### PR TITLE
[EWT-361] Fix broken regex pattern for extracting dataflow job id

### DIFF
--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -33,6 +33,11 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 DEFAULT_DATAFLOW_LOCATION = 'us-central1'
 
 
+JOB_ID_PATTERN = re.compile(
+    r'Submitted job: (?P<job_id_java>.*)|Created job with id: \[(?P<job_id_python>.*)\]'
+)
+
+
 class _DataflowJob(LoggingMixin):
     def __init__(self, dataflow, project_number, name, location, poll_sleep=10,
                  job_id=None, num_retries=None):
@@ -128,25 +133,25 @@ class _Dataflow(LoggingMixin):
 
     def _line(self, fd):
         if fd == self._proc.stderr.fileno():
-            line = b''.join(self._proc.stderr.readlines())
+            line = self._proc.stderr.readline().decode()
             if line:
-                self.log.warning(line[:-1])
+                self.log.warning(line.rstrip("\n"))
             return line
         if fd == self._proc.stdout.fileno():
-            line = b''.join(self._proc.stdout.readlines())
+            line = self._proc.stdout.readline().decode()
             if line:
-                self.log.info(line[:-1])
+                self.log.info(line.rstrip("\n"))
             return line
+
+        raise Exception("No data in stderr or in stdout.")
 
     @staticmethod
     def _extract_job(line):
         # Job id info: https://goo.gl/SE29y9.
         # [EWT-361] : Fixes out of date regex to extract job id
-        job_id_pattern = re.compile(
-            br'.*console.cloud.google.com\/dataflow.*\/jobs\/[a-z|0-9|A-Z|\-|\_]+\/([a-z|0-9|A-Z|\-|\_]+).*')
-        matched_job = job_id_pattern.search(line or '')
+        matched_job = JOB_ID_PATTERN.search(line or '')
         if matched_job:
-            return matched_job.group(1).decode()
+            return matched_job.group('job_id_java') or matched_job.group('job_id_python')
 
     def wait_for_done(self):
         reads = [self._proc.stderr.fileno(), self._proc.stdout.fileno()]

--- a/airflow/contrib/hooks/gcp_dataflow_hook.py
+++ b/airflow/contrib/hooks/gcp_dataflow_hook.py
@@ -141,8 +141,9 @@ class _Dataflow(LoggingMixin):
     @staticmethod
     def _extract_job(line):
         # Job id info: https://goo.gl/SE29y9.
+        # [EWT-361] : Fixes out of date regex to extract job id
         job_id_pattern = re.compile(
-            br'.*console.cloud.google.com/dataflow.*/jobs/([a-z|0-9|A-Z|\-|\_]+).*')
+            br'.*console.cloud.google.com\/dataflow.*\/jobs\/[a-z|0-9|A-Z|\-|\_]+\/([a-z|0-9|A-Z|\-|\_]+).*')
         matched_job = job_id_pattern.search(line or '')
         if matched_job:
             return matched_job.group(1).decode()

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,5 +18,5 @@
 # under the License.
 #
 
-version = '1.10.4+twtr11'
+version = '1.10.4+twtr12'
 


### PR DESCRIPTION

Make sure you have checked _all_ steps below.

### JIRA
- [ ] My PR addresses the following [EWT JIRA]
    - https://jira.twitter.biz/browse/EWT-361



### Description
- [ ] The airflow 1.10.4 regex for extracting job id from the dataflow monitoring job url is out of date causing it to extract the location instead. Thus the task fails even though the dataflow job runs successfully.


### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"


### Documentation
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.


### Code Quality
- [ ] Passes `flake8`
