### PR TITLE
[EWT-350][partial CP 1428c0f] Pinning max pandas version to 2.0 (lesser than) to allow pandas 1.0

### DIFF
--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,5 +18,5 @@
 # under the License.
 #
 
-version = '1.10.4+twtr13'
+version = '1.10.4+twtr14'
 

--- a/setup.py
+++ b/setup.py
@@ -347,7 +347,7 @@ def do_setup():
             'jinja2>=2.10.1, <2.11.0',
             'lazy_object_proxy~=1.3',
             'markdown>=2.5.2, <3.0',
-            'pandas>=0.17.1, <1.0.0',
+            'pandas>=0.17.1, <2.0.0',
             'pendulum==1.4.4',
             'psutil>=4.2.0, <6.0.0',
             'pygments>=2.0.1, <3.0',


### PR DESCRIPTION
JIRA: https://jira.twitter.biz/browse/EWT-350
