### PR TITLE
[TWTTR] Don't enqueue tasks again if already queued

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -57,9 +57,10 @@ class BaseExecutor(LoggingMixin):
         key = simple_task_instance.key
         if key not in self.queued_tasks and key not in self.running:
             self.log.info("Adding to queue: %s", command)
+            self.queued_tasks[key] = (command, priority, queue, simple_task_instance)
         else:
-            self.log.info("Adding to queue even though already queued or running {}".format(command, key))
-        self.queued_tasks[key] = (command, priority, queue, simple_task_instance)
+            self.log.info("Task already queued or running {}".format(command, key))
+
 
     def queue_task_instance(
             self,

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -59,8 +59,7 @@ class BaseExecutor(LoggingMixin):
             self.log.info("Adding to queue: %s", command)
             self.queued_tasks[key] = (command, priority, queue, simple_task_instance)
         else:
-            self.log.info("Task already queued or running {}".format(command, key))
-
+            self.log.error("could not queue task %s", key)
 
     def queue_task_instance(
             self,

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -155,6 +155,14 @@ class CeleryExecutor(BaseExecutor):
             self._sync_parallelism
         )
 
+    def queue_command(self, simple_task_instance, command, priority=1, queue=None):
+        key = simple_task_instance.key
+        if key not in self.queued_tasks and key not in self.running:
+            self.log.info("Adding to queue: %s", command)
+        else:
+            self.log.info("Adding to queue even though already queued or running {}".format(command, key))
+        self.queued_tasks[key] = (command, priority, queue, simple_task_instance)
+
     def _num_tasks_per_send_process(self, to_send_count):
         """
         How many Celery tasks should each worker process send.

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,5 +18,5 @@
 # under the License.
 #
 
-version = '1.10.4+twtr20'
+version = '1.10.4+twtr21'
 

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,5 +18,5 @@
 # under the License.
 #
 
-version = '1.10.4+twtr19'
+version = '1.10.4+twtr20'
 


### PR DESCRIPTION
Found that some tasks are being run twice and sometimes even thrice with K8sExecutors. The fix I did here already exists in the masters, but could not track the source jira/issue of that.

https://github.com/apache/airflow/blob/master/airflow/executors/base_executor.py#L71