### PR TITLE
EWT-569 : Airflow Upgrade DB Fix

### DIFF
--- a/airflow/migrations/versions/952da73b5eff_add_dag_code_table.py
+++ b/airflow/migrations/versions/952da73b5eff_add_dag_code_table.py
@@ -26,6 +26,8 @@ Create Date: 2020-03-12 12:39:01.797462
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy import text
+from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
 from airflow.models.dagcode import DagCode
@@ -56,6 +58,10 @@ def upgrade():
                     sa.Column('fileloc', sa.String(length=2000), nullable=False),
                     sa.Column('source_code', sa.UnicodeText(), nullable=False),
                     sa.Column('last_updated', sa.TIMESTAMP(timezone=True), nullable=False))
+
+    op.alter_column(table_name='dag_code', column_name='last_updated',
+        type_=mysql.TIMESTAMP(fsp=6), nullable=False,
+        server_default=text('CURRENT_TIMESTAMP(6)'))
 
     conn = op.get_bind()
     if conn.dialect.name not in ('sqlite'):

--- a/airflow/migrations/versions/952da73b5eff_add_dag_code_table.py
+++ b/airflow/migrations/versions/952da73b5eff_add_dag_code_table.py
@@ -59,9 +59,11 @@ def upgrade():
                     sa.Column('source_code', sa.UnicodeText(), nullable=False),
                     sa.Column('last_updated', sa.TIMESTAMP(timezone=True), nullable=False))
 
-    op.alter_column(table_name='dag_code', column_name='last_updated',
-        type_=mysql.TIMESTAMP(fsp=6), nullable=False,
-        server_default=text('CURRENT_TIMESTAMP(6)'))
+    op.alter_column(table_name='dag_code',
+                    column_name='last_updated',
+                    type_=mysql.TIMESTAMP(fsp=6),
+                    nullable=False,
+                    server_default=text('CURRENT_TIMESTAMP(6)'))
 
     conn = op.get_bind()
     if conn.dialect.name not in ('sqlite'):

--- a/airflow/migrations/versions/a66efa278eea_add_precision_to_execution_date_in_mysql.py
+++ b/airflow/migrations/versions/a66efa278eea_add_precision_to_execution_date_in_mysql.py
@@ -26,6 +26,7 @@ Create Date: 2020-06-16 21:44:02.883132
 
 from alembic import op
 from sqlalchemy.dialects import mysql
+from sqlalchemy import text
 
 # revision identifiers, used by Alembic.
 revision = 'a66efa278eea'
@@ -45,7 +46,8 @@ def upgrade():
             table_name=TABLE_NAME,
             column_name=COLUMN_NAME,
             type_=mysql.TIMESTAMP(fsp=6),
-            nullable=False
+            nullable=False,
+            server_default=text('CURRENT_TIMESTAMP(6)')
         )
 
 

--- a/airflow/migrations/versions/d38e04c12aa2_add_serialized_dag_table.py
+++ b/airflow/migrations/versions/d38e04c12aa2_add_serialized_dag_table.py
@@ -26,6 +26,7 @@ Create Date: 2019-08-01 14:39:35.616417
 from alembic import op
 from sqlalchemy.dialects import mysql
 import sqlalchemy as sa
+from sqlalchemy import text
 
 # revision identifiers, used by Alembic.
 revision = 'd38e04c12aa2'
@@ -61,16 +62,13 @@ def upgrade():
         conn.execute("SET time_zone = '+00:00'")
         cur = conn.execute("SELECT @@explicit_defaults_for_timestamp")
         res = cur.fetchall()
-        if res[0][0] == 0:
-            raise Exception(
-                "Global variable explicit_defaults_for_timestamp needs to be on (1) for mysql"
-            )
 
         op.alter_column(  # pylint: disable=no-member
             table_name="serialized_dag",
             column_name="last_updated",
             type_=mysql.TIMESTAMP(fsp=6),
             nullable=False,
+            server_default=text('CURRENT_TIMESTAMP(6)')
         )
     else:
         # sqlite and mssql datetime are fine as is.  Therefore, not converting

--- a/airflow/migrations/versions/d38e04c12aa2_add_serialized_dag_table.py
+++ b/airflow/migrations/versions/d38e04c12aa2_add_serialized_dag_table.py
@@ -68,8 +68,7 @@ def upgrade():
             column_name="last_updated",
             type_=mysql.TIMESTAMP(fsp=6),
             nullable=False,
-            server_default=text('CURRENT_TIMESTAMP(6)')
-        )
+            server_default=text('CURRENT_TIMESTAMP(6)'))
     else:
         # sqlite and mssql datetime are fine as is.  Therefore, not converting
         if conn.dialect.name in ("sqlite", "mssql"):


### PR DESCRIPTION
EWT - 569 : Airflow Upgrade to 1.10.14

This Pull Request contains the changes in airflow migrations for proper functioning.

Files Changed :

airflow/migrations/versions/952da73b5eff_add_dag_code_table.py
airflow/migrations/versions/a66efa278eea_add_precision_to_execution_date_in_mysql.py
airflow/migrations/versions/d38e04c12aa2_add_serialized_dag_table.py

Testing has been done on local by creating new Databases.