### PR TITLE
[CP][EWT-797] Fixing max_active_runs to control the number of runs running…

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -798,6 +798,7 @@ class SchedulerJob(BaseJob):
             run.verify_integrity(session=session)
             ready_tis = run.update_state(session=session)
             if run.state == State.RUNNING:
+                active_dag_runs.append(run)
                 self.log.debug("Examining active DAG run: %s", run)
                 for ti in ready_tis:
                     self.log.debug('Queuing task: %s', ti)

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,7 +18,7 @@
 # under the License.
 #
 
-version = '1.10.14+twtr2'
+version = '1.10.14+twtr3'
 
 
 


### PR DESCRIPTION
… simultaneously

closes: EWT-797
related: EWT-797


I referred the git issue: https://github.com/apache/airflow/issues/9975 which in its first line itself tells that the issue that happens related to max_active_runs in 1.10.14 is a separate one and is discussed here: https://github.com/apache/airflow/issues/13802

This issue was resolved but the fix went in 1.10.15 version. I took the same fix: https://github.com/apache/airflow/pull/13803/files and have applied it in this commit (5e87232fb34cfa61858d941649345ef7fa928a1b). 

The resolution worked and I did the testing on gke devel cluster: https://airflow-smantri--devel--etl-workflow-users.service.qus1.twitter.biz/admin/airflow/tree?dag_id=bq_dal_integration_dag

Prior to the fix, if the max_active_runs = 1, and if you start more than 1 run simultaneously, all of them will start their tasks, and would not honour max_active_runs configuration.

With this fix, if the max_active_runs = 1, and one of the run is going on while the second run is triggered, the second run starts with the start_date being the time when it is triggered, but the second run won't start any of its tasks until the prior run is complete.